### PR TITLE
Fixed Data types for input on getScoreboard() and getBoxscore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ pom.xml.releaseBackup
 .project
 
 .classpath
+/bin/

--- a/src/main/java/com/drmilk/nbawrapper/domain/League.java
+++ b/src/main/java/com/drmilk/nbawrapper/domain/League.java
@@ -37,7 +37,7 @@ public class League {
 		}
 	}
 
-	public static Boxscore getBoxscore(Integer day, Integer month, Integer year, String gameId) throws BoxscoreNotFoundException {
+	public static Boxscore getBoxscore(String day, String month, String year, String gameId) throws BoxscoreNotFoundException {
 		try {
 			HttpResponse boxscoreResponse = QueryManager.getHttpResponse(
 					sourceBaseUrl + "/" + year.toString() + month.toString() + day.toString() + "/" + gameId + "_boxscore.json");

--- a/src/main/java/com/drmilk/nbawrapper/domain/League.java
+++ b/src/main/java/com/drmilk/nbawrapper/domain/League.java
@@ -25,7 +25,7 @@ public class League {
 
 	private static ObjectMapper objectMapper = (ObjectMapper) context.getBean("objectMapper");
 
-	public static Scoreboard getScoreboard(Integer day, Integer month, Integer year)
+	public static Scoreboard getScoreboard(String day, String month, String year)
 			throws ScoreboardNotFoundException {
 		try {
 			HttpResponse scoreboardResponse = QueryManager.getHttpResponse(

--- a/src/test/java/com/drmilk/nbawrapper/domain/LeagueTest.java
+++ b/src/test/java/com/drmilk/nbawrapper/domain/LeagueTest.java
@@ -31,7 +31,7 @@ public class LeagueTest extends TestCase {
 	}
 
 	public void testGetValidBoxscore() throws BoxscoreNotFoundException {
-		Boxscore boxscore = League.getBoxscore(25, 12, 2016, "0021600457");
+		Boxscore boxscore = League.getBoxscore("25", "12", "2016", "0021600457");
 		Assert.assertNotNull(boxscore);
 		Assert.assertEquals("109", boxscore.getBasicGameData().getHomeTeam().getScore());
 		Assert.assertEquals("108", boxscore.getBasicGameData().getVisitingTeam().getScore());

--- a/src/test/java/com/drmilk/nbawrapper/domain/LeagueTest.java
+++ b/src/test/java/com/drmilk/nbawrapper/domain/LeagueTest.java
@@ -14,7 +14,7 @@ import junit.framework.TestCase;
 public class LeagueTest extends TestCase {
 
 	public void testGetValidScoreboard() throws ScoreboardNotFoundException {
-		Scoreboard league = League.getScoreboard(25, 12, 2016);
+		Scoreboard league = League.getScoreboard("25", "12", "2016");
 		Assert.assertNotNull(league);
 		List<GameDetails> gameList = league.getGames();
 		Assert.assertEquals(5, gameList.size());


### PR DESCRIPTION
Changed from int to String in order to be able to handle singular month and days (the leading 0 in days 1-9 of the month were being removed) in order to properly format string and return data without "scoreboard or boxscore not found" exceptions.